### PR TITLE
el-popover中使用el-tabs的样式显示问题

### DIFF
--- a/source/_posts/el-popover中使用el-tabs的样式显示问题.md
+++ b/source/_posts/el-popover中使用el-tabs的样式显示问题.md
@@ -1,0 +1,40 @@
+---
+title: el-popover中使用el-tabs的样式显示问题
+tags: 前端、UI组件
+categories: 前端
+date: 2019-03-29
+comments: true
+---
+
+## 前言
+笔者最近在写一个管理后台的项目，技术栈选的是vue+element-ui。有一个需求是在一个表格的操作栏中点击按钮展示出价记录和入场券记录，如下图所示
+![](https://drafish.github.io/static-files/imgs/20190329100057.jpg)
+<!-- more -->
+
+产品的原意应该是让我用dialog对话框来做，但笔者觉得对话框太重了，想用一个更加轻量的组件popover。看了下官方文档，官方已经给出了popover中嵌套table的demo，ctrl+c、ctrl+v，美滋滋。自己只需要在官方demo的基础上再加个el-tabs组件就可以了。代码写完了一跑，发现el-tabs组件的tab-bar没显示出来。下图左边是实际展示效果，右边是正常应该展示的效果。
+![](https://drafish.github.io/static-files/imgs/20190329110202.jpg)
+
+## 问题分析
+问题原因有两点：
+* el-popover利用display属性来控制popover框的显示和隐藏
+* el-tabs中tab-bar的属性通过计算tab的物理宽高获得
+
+这两个组件单独使用不会有问题。但组合使用时，当popover框处于隐藏状态时，el-tabs中tab的物理宽高都为0。进而导致tab-bar的属性计算异常。
+
+## 解决方案
+简单介绍下解决思路。要解决这个问题，主要就是要解决如何在隐藏状态下获取tab的物理宽高。说到这里，有经验的同学可能已经想到了用visibility:hidden来隐藏组件。但这个方式有一个问题，被隐藏的组件会影响文档布局。所以再加一个position:absolute，使组件脱离文档流。
+
+总结下解决方案，就是将el-popover的隐藏方式从display:none改成visibility:hidden;position:absolute。
+
+笔者已将这个解决方案提了个[pull request](https://github.com/ElemeFE/element/pull/14891)给element，希望能被merge。
+
+但笔者眼前的问题还是没有解决，element官方接不接受我的pr还不一定呢。就算将来能接受，那现在一时半会儿也用不上。得有一个临时解决方案填这个坑。
+
+## 临时解决方案
+### 方案一
+将el-popover组件的源码复制出来，写一个自定义的组件，并修改隐藏方式。在项目中引入自定义组件来替代el-popover。
+
+### 方案二
+利用el-popover的show事件和after-enter事件，在显示触发时将el-tabs绑定的model置空，在显示完成时为model重新赋值。原理是通过改变el-tabs的model值，触发tab-bar重新计算style属性。
+
+笔者项目中用的就是方案二，因为方案二只要加两行代码就能搞定，方案一要多写好多代码。

--- a/source/_posts/央行征信爬虫解决方案.md
+++ b/source/_posts/央行征信爬虫解决方案.md
@@ -10,11 +10,11 @@ comments: true
 
 笔者所在公司是一家互联网金融公司，其中最大的一块业务就是贷款。当一个用户向我们申请贷款时，我们需要用户授权获取用户的征信数据，然后将数据交给风控规则引擎生成一份数据报告，凭借这份数据报告来判断是否可以给这个用户放贷。
 <!-- more -->
-![](https://ws3.sinaimg.cn/large/005BYqpgly1g1aos4pnerj30l506sjrv.jpg)
+![](https://drafish.github.io/static-files/imgs/entirety.png)
 其中获取用户征信数据这一步就是用爬虫来实现的。爬虫的应用领域非常广泛，技术手段也是五花八门。本文主要以央行征信报告为爬取目标，讲解三种爬虫的技术解决方案。
 
 ## 方案一：基于接口的爬虫
-![](https://ws3.sinaimg.cn/large/005BYqpgly1g1aosxziw7j30em0d3dgk.jpg)
+![](https://drafish.github.io/static-files/imgs/api_crawler.png)
 ### 技术栈：
 * nodejs
 * request
@@ -34,7 +34,7 @@ comments: true
 这个方案其实本来是最佳方案。但后来央行征信改版，登录页密码框改用ActiveX控件来加密用户密码。纯接口的方式无法通过央行征信的登录验证，所以该方案现在已经不可用了。
 
 ## 方案二：基于浏览器的爬虫
-![](https://ws3.sinaimg.cn/large/005BYqpgly1g1aotdsbsgj30hy0d3jsj.jpg)
+![](https://drafish.github.io/static-files/imgs/browser_crawler.png)
 ### 技术栈：
 * nodejs
 * selenium
@@ -55,7 +55,7 @@ comments: true
 由于ActiveX控件只能在IE浏览器中才能加载，所以爬虫程序必须部署在windows机器上，也就是图中的worker机。另外，ActiveX控件的密码无法通过代码直接复制，必须依赖驱动级键盘输入来输入用户密码。
 
 ## 方案三：基于浏览器+接口的爬虫
-![](https://ws3.sinaimg.cn/large/005BYqpggy1g1aotpz7cvj30ho0eht9t.jpg)
+![](https://drafish.github.io/static-files/imgs/api_browser_crawler.png)
 ### 技术栈：
 * nodejs
 * selenium


### PR DESCRIPTION
顺便改了下央行征信爬虫博客的图片链接，现在图片链接都改用自己的github提供的链接